### PR TITLE
Fix the single qubit op wires for CNOT & handle requests with ERROR

### DIFF
--- a/pennylane_aqt/device.py
+++ b/pennylane_aqt/device.py
@@ -178,10 +178,12 @@ class AQTDevice(QubitDevice):
             job = submit(self.HTTP_METHOD, self.hostname, job_query_data, self.header).json()
             sleep(self.retry_delay)
 
-        error_msg = job.get('ERROR', None)
+        error_msg = job.get("ERROR", None)
 
         if error_msg:
-            raise ValueError(f"Something went wrong with the request, got the error message: {error_msg}")
+            raise ValueError(
+                f"Something went wrong with the request, got the error message: {error_msg}"
+            )
 
         self.samples = job["samples"]
 

--- a/pennylane_aqt/device.py
+++ b/pennylane_aqt/device.py
@@ -178,6 +178,11 @@ class AQTDevice(QubitDevice):
             job = submit(self.HTTP_METHOD, self.hostname, job_query_data, self.header).json()
             sleep(self.retry_delay)
 
+        error_msg = job.get('ERROR', None)
+
+        if error_msg:
+            raise ValueError(f"Something went wrong with the request, got the error message: {error_msg}")
+
         self.samples = job["samples"]
 
     def _apply_operation(self, operation):
@@ -227,11 +232,11 @@ class AQTDevice(QubitDevice):
             return
 
         if op_name == "CNOT":
-            self._append_op_to_queue("RY", np.pi / 2, device_wire_labels[0])
+            self._append_op_to_queue("RY", np.pi / 2, [device_wire_labels[0]])
             self._append_op_to_queue("MS", np.pi / 4, device_wire_labels)
-            self._append_op_to_queue("RX", -np.pi / 2, device_wire_labels[0])
-            self._append_op_to_queue("RX", -np.pi / 2, device_wire_labels[1])
-            self._append_op_to_queue("RY", -np.pi / 2, device_wire_labels[0])
+            self._append_op_to_queue("RX", -np.pi / 2, [device_wire_labels[0]])
+            self._append_op_to_queue("RX", -np.pi / 2, [device_wire_labels[1]])
+            self._append_op_to_queue("RY", -np.pi / 2, [device_wire_labels[0]])
             return
 
         if op_name == "S":

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -600,7 +600,7 @@ class TestAQTSimulatorDevices:
         assert dev.header[API_HEADER_KEY] == SOME_API_KEY
 
     @pytest.mark.skip("API key needs to be inputted")
-    def test_simulator_default_init(self, num_wires, shots):
+    def test_simulator_cnot(self):
         """Test that the CNOT operation is decomposed correctly."""
         dev = qml.device("aqt.sim", wires=2, api_key="<Insert API Key here>")
 

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -318,8 +318,8 @@ class TestAQTDevice:
             dev.apply([qml.RX(0.5, wires=1), qml.QubitStateVector(state, wires=[0, 1, 2])])
 
     def test_apply_raises_for_error(self, monkeypatch):
-        """Tests that the apply method raises an exception an Error has been
-        recorded in the response."""
+        """Tests that the apply method raises an exception when an Error has
+        been recorded in the response."""
 
         dev = AQTDevice(3, api_key=SOME_API_KEY)
 

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -194,7 +194,7 @@ class TestAQTDevice:
 
         assert dev.circuit == [["X", 1.0, wires], ["Y", -0.5, wires]]
 
-    @pytest.mark.parametrize("wires", [[0, 1], [1, 0], [1, 2], [2, 1], [0,2], [2,0]])
+    @pytest.mark.parametrize("wires", [[0, 1], [1, 0], [1, 2], [2, 1], [0, 2], [2, 0]])
     def test_operation_cnot(self, wires):
         """Tests that the _apply_operation method correctly populates the circuit
         queue when a PennyLane CNOT operation is provided."""
@@ -204,7 +204,7 @@ class TestAQTDevice:
 
         dev._apply_operation(qml.CNOT(wires=wires))
 
-    # Note: the original parameters used in PennyLane are divided by pi as per AQT convetion
+        # Note: the original parameters used in PennyLane are divided by pi as per AQT convetion
         assert dev.circuit == [
             ["Y", 1 / 2, wires[0]],
             ["MS", 1 / 4, wires],
@@ -326,12 +326,11 @@ class TestAQTDevice:
         some_error_msg = "Error happened."
 
         class MockResponse:
-
             def __init__(self):
                 self.status_code = 200
 
             def json(self):
-                return {"ERROR": some_error_msg, 'status': 'finished', "id" : 1}
+                return {"ERROR": some_error_msg, "status": "finished", "id": 1}
 
         monkeypatch.setattr(pennylane_aqt.device, "submit", lambda *args, **kwargs: MockResponse())
         with pytest.raises(ValueError, match="Something went wrong with the request"):
@@ -607,7 +606,7 @@ class TestAQTSimulatorDevices:
 
         @qml.qnode(dev)
         def circuit():
-            qml.CNOT(wires=[0,1])
+            qml.CNOT(wires=[0, 1])
             return qml.expval(qml.PauliZ(0))
 
         assert circuit() == 1

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -206,11 +206,11 @@ class TestAQTDevice:
 
         # Note: the original parameters used in PennyLane are divided by pi as per AQT convetion
         assert dev.circuit == [
-            ["Y", 1 / 2, wires[0]],
+            ["Y", 1 / 2, [wires[0]]],
             ["MS", 1 / 4, wires],
-            ["X", -1 / 2, wires[0]],
-            ["X", -1 / 2, wires[1]],
-            ["Y", -1 / 2, wires[0]],
+            ["X", -1 / 2, [wires[0]]],
+            ["X", -1 / 2, [wires[1]]],
+            ["Y", -1 / 2, [wires[0]]],
         ]
 
     @pytest.mark.parametrize("wires", [[0], [1], [2]])


### PR DESCRIPTION
**Context**

A minor error in the way how wires are defined for single-qubit operations caused a request error when using the CNOT operation.

**Changes**

* Adjusted the wires in the decomposition of CNOT
* Added a case for handling requests that return a message with the `ERROR` field specified

**Related issues**

#17 