### PR TITLE
Add response details when raising `HTTPError`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,18 +6,22 @@
 
 ### Improvements
 
+* Raising an `HTTPError` now provides more information about the exact issues
+  by using the underlying response object.
+  [(#27)](https://github.com/XanaduAI/pennylane-aqt/pull/27)
+
 ### Documentation
 
 ### Bug fixes
 
-* Fixed `MS` gate parameter in `CNOT` gate decomposition
+* Fixed `MS` gate parameter in `CNOT` gate decomposition.
   [(#26)](https://github.com/XanaduAI/pennylane-aqt/pull/26)
 
 ### Contributors
 
 This release contains contributions from (in alphabetical order):
 
-Tamás Varga
+Christina Lee, Antal Száva, Tamás Varga
 
 ---
 

--- a/pennylane_aqt/api_client.py
+++ b/pennylane_aqt/api_client.py
@@ -55,7 +55,7 @@ def verify_valid_status(response):
         requests.HTTPError: if the status is not valid
     """
     if response.status_code not in VALID_STATUS_CODES:
-        raise requests.HTTPError
+        raise requests.HTTPError(response, response.text)
 
 
 def submit(request_type, url, request, headers):

--- a/pennylane_aqt/device.py
+++ b/pennylane_aqt/device.py
@@ -235,7 +235,7 @@ class AQTDevice(QubitDevice):
 
         if op_name == "CNOT":
             self._append_op_to_queue("RY", np.pi / 2, [device_wire_labels[0]])
-            self._append_op_to_queue("MS", np.pi / 4, device_wire_labels)
+            self._append_op_to_queue("MS", np.pi / 2, device_wire_labels)
             self._append_op_to_queue("RX", -np.pi / 2, [device_wire_labels[0]])
             self._append_op_to_queue("RX", -np.pi / 2, [device_wire_labels[1]])
             self._append_op_to_queue("RY", -np.pi / 2, [device_wire_labels[0]])

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -610,3 +610,16 @@ class TestAQTSimulatorDevices:
             return qml.expval(qml.PauliZ(0))
 
         assert circuit() == 1
+
+    @pytest.mark.skip("API key needs to be inputted")
+    def test_too_many_shots_for_aqt(self):
+        """Test >200 shots is invalid with AQT."""
+        dev = qml.device("aqt.sim", wires=2, api_key="<Insert API Key here>", shots=201)
+
+        @qml.qnode(dev)
+        def circuit():
+            qml.CNOT(wires=[0, 1])
+            return qml.expval(qml.PauliZ(0))
+
+        with pytest.raises(requests.HTTPError, match='Invalid number of repetitions provided!'):
+            circuit()


### PR DESCRIPTION
**Context**

When a request returns an invalid code, an `HTTPError` is raised. However, there are no details specified for the exact cause.

**Changes**

Uses the response object to provide more information with the `HTTPError`.

For example, executing a QNode with a device that has more than 200 shots will now raise an error as such:
```
HTTPError: [Errno <Response [400]>] {"ERROR":"Bad simulation request: Invalid number of repetitions provided! Only values [1 .. 200] allowed, but value 201 was provided.","status":"error"}
```