### PR TITLE
manually bump plugin version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Release 0.28.0
+# Release 0.29.0
 
 ### New features since last release
 

--- a/pennylane_aqt/_version.py
+++ b/pennylane_aqt/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.28.0"
+__version__ = "0.29.0"


### PR DESCRIPTION
0.28 was never released, but the changelog and _version file were already updated in #44. I'm just manually changing those things to 0.29, and we'll catch it this time!