### PR TITLE
Add `StatePrep` in tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,13 @@
-# Release 0.30.0-dev
+# Release 0.32.0-dev
 
 ### New features since last release
 
 ### Breaking changes
 
 ### Improvements
+
+* Added support for `qml.StatePrep` as a state preparation operation.
+  [(#50)](https://github.com/PennyLaneAI/pennylane-aqt/pull/50)
 
 ### Documentation
 
@@ -13,6 +16,8 @@
 ### Contributors
 
 This release contains contributions from (in alphabetical order):
+
+ Jay Soni
 
 ---
 # Release 0.29.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,18 +2,18 @@
 
 ### New features since last release
 
-### Breaking changes
+### Breaking changes 💔
 
-### Improvements
+### Improvements 🛠
 
 * Added support for `qml.StatePrep` as a state preparation operation.
   [(#50)](https://github.com/PennyLaneAI/pennylane-aqt/pull/50)
 
-### Documentation
+### Documentation 📝
 
-### Bug fixes
+### Bug fixes 🐛
 
-### Contributors
+### Contributors ✍️
 
 This release contains contributions from (in alphabetical order):
 

--- a/pennylane_aqt/device.py
+++ b/pennylane_aqt/device.py
@@ -164,7 +164,7 @@ class AQTDevice(QubitDevice):
         rotations = kwargs.pop("rotations", [])
 
         for i, operation in enumerate(operations):
-            if i > 0 and operation.name in {"BasisState", "QubitStateVector"}:
+            if i > 0 and operation.name in {"BasisState", "QubitStateVector", "StatePrep"}:
                 raise DeviceError(
                     "The operation {} is only supported at the beginning of a circuit.".format(
                         operation.name

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -1,2 +1,2 @@
-pennylane
+git+https://github.com/PennyLaneAI/pennylane.git
 requests

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -307,15 +307,16 @@ class TestAQTDevice:
         with pytest.raises(qml.DeviceError, match="only supported at the beginning of a circuit"):
             dev.apply([qml.RX(0.5, wires=1), qml.BasisState(np.array([1, 1, 1]), wires=[0, 1, 2])])
 
-    def test_apply_qubitstatevector_not_first_exception(self):
-        """Tests that the apply method raises an exception when QubitStateVector
+    @pytest.mark.parametrize("op", [qml.StatePrep, qml.QubitStateVector])
+    def test_apply_statevector_not_first_exception(self, op):
+        """Tests that the apply method raises an exception when QubitStateVector or StatePrep
         is not the first operation."""
 
         dev = AQTDevice(2, api_key=SOME_API_KEY)
 
         state = np.ones(8) / np.sqrt(8)
         with pytest.raises(qml.DeviceError, match="only supported at the beginning of a circuit"):
-            dev.apply([qml.RX(0.5, wires=1), qml.QubitStateVector(state, wires=[0, 1, 2])])
+            dev.apply([qml.RX(0.5, wires=1), op(state, wires=[0, 1, 2])])
 
     def test_apply_raises_for_error(self, monkeypatch):
         """Tests that the apply method raises an exception when an Error has


### PR DESCRIPTION
Following the work [here](https://github.com/PennyLaneAI/pennylane/pull/4450/), we make sure that the pennylane-aqt plugin supports both operators and defaults to using `StatePrep` where appropriate until it is deprecated.