### PR TITLE
put back pennylane version

### DIFF
--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -1,2 +1,2 @@
-git+https://github.com/PennyLaneAI/pennylane.git
+pennylane
 requests


### PR DESCRIPTION
turns out CI [uses master](https://github.com/PennyLaneAI/pennylane-aqt/blob/5b573912774dd444063d6910929e6393dc9bc53d/.github/workflows/tests.yml#L30) anyway. let's put this back now?