### PR TITLE
Update workflow badge URL

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 PennyLane-AQT Plugin
 ####################
 
-.. image:: https://img.shields.io/github/workflow/status/PennyLaneAI/pennylane-aqt/Tests/master?logo=github&style=flat-square
+.. image:: https://img.shields.io/github/actions/workflow/status/PennyLaneAI/pennylane-aqt/tests.yml?branch=master&logo=github&style=flat-square
     :alt: GitHub Workflow Status (branch)
     :target: https://github.com/PennyLaneAI/pennylane-aqt/actions?query=workflow%3ATests
 


### PR DESCRIPTION
This PR updates the workflow badge URL to ensure it accurately reflects the project's build status. The changes are based on the instructions provided in [https://github.com/badges/shields/issues/8671](https://github.com/badges/shields/issues/8671).