### PR TITLE
Fix deprecated import path for `QubitDevice`

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -17,8 +17,6 @@ networkx==2.8
 ninja==1.10.2.3
 numpy==1.22.3
 packaging>24
-PennyLane==0.31.0
-PennyLane-Lightning==0.31.0
 Pygments==2.11.2
 pyparsing==3.0.8
 pytz==2022.1
@@ -40,3 +38,5 @@ urllib3==1.26.9
 # do not pin
 pennylane-sphinx-theme
 zipp==3.8
+PennyLane
+PennyLane-Lightninggit

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,7 +1,7 @@
 alabaster==0.7.12
 appdirs==1.4.4
 autograd==1.4
-autoray==0.6.3
+autoray
 Babel==2.10.1
 cachetools==5.0.0
 certifi==2021.10.8
@@ -39,4 +39,4 @@ urllib3==1.26.9
 pennylane-sphinx-theme
 zipp==3.8
 PennyLane
-PennyLane-Lightninggit
+PennyLane-Lightning

--- a/pennylane_aqt/device.py
+++ b/pennylane_aqt/device.py
@@ -23,7 +23,8 @@ import json
 from time import sleep
 
 import numpy as np
-from pennylane import QubitDevice, DeviceError
+from pennylane import DeviceError
+from pennylane.devices import QubitDevice
 from pennylane.ops import Adjoint
 
 from ._version import __version__


### PR DESCRIPTION
pennylane.QubitDevice is deprecated in v0.39, importing QubitDevice from pennylane.devices instead.