### PR TITLE
Drop support for Python 3.9 and add support for Python 3.12

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,10 +27,6 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: Install setuptools if Python 3.12
-        if: startsWith(matrix.python-version, '3.12')
-        run: python -m pip install --upgrade pip setuptools
-
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
@@ -40,6 +36,7 @@ jobs:
 
       - name: Install Plugin
         run: |
+          python -m pip install --upgrade setuptools
           python setup.py bdist_wheel
           pip install dist/PennyLane*.whl
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.9', '3.10', '3.11']
+        python-version: ['3.10', '3.11', '3.12']
 
     steps:
       - name: Cancel Previous Runs

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,6 +27,10 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
+      - name: Install setuptools if Python 3.12
+        if: startsWith(matrix.python-version, '3.12')
+        run: python -m pip install --upgrade pip setuptools
+
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/upload.yml
+++ b/.github/workflows/upload.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.9
+          python-version: 3.10
 
       - name: Build and install Plugin
         run: |

--- a/.github/workflows/upload.yml
+++ b/.github/workflows/upload.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.10
+          python-version: "3.10"
 
       - name: Build and install Plugin
         run: |

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -9,7 +9,7 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.9"
+    python: "3.10"
   apt_packages:
     - graphviz
 

--- a/README.rst
+++ b/README.rst
@@ -55,10 +55,12 @@ Features
 Installation
 ============
 
-**Note:** If you are using Python 3.12, ensure `setuptools` is up to date by running:
-::
+.. note::
+    
+    If you are using Python 3.12, ensure `setuptools` is up to date prior to installation:
+    ::
 
-    $ python3 -m pip install --upgrade setuptools
+        $ python3 -m pip install --upgrade setuptools
 
 PennyLane-AQT only requires PennyLane for use, no additional external frameworks are needed.
 The plugin can be installed via ``pip``:

--- a/README.rst
+++ b/README.rst
@@ -55,7 +55,9 @@ Features
 Installation
 ============
 
-PennyLane-AQT requires Python >= 3.10.
+PennyLane-AQT requires Python >= 3.10. If you currently do not have Python 3 installed,
+we recommend `Anaconda for Python 3 <https://www.anaconda.com/download/>`_, a distributed
+version of Python packaged for scientific computation.
 
 .. warning::
     
@@ -74,11 +76,6 @@ Alternatively, you can install PennyLane-AQT from the source code by navigating 
 ::
 
     $ python3 setup.py install
-
-
-If you currently do not have Python 3 installed,
-we recommend `Anaconda for Python 3 <https://www.anaconda.com/download/>`_, a distributed
-version of Python packaged for scientific computation.
 
 Software tests
 ~~~~~~~~~~~~~~

--- a/README.rst
+++ b/README.rst
@@ -55,6 +55,11 @@ Features
 Installation
 ============
 
+**Note:** If you are using Python 3.12, ensure `setuptools` is up to date by running:
+::
+
+    $ python3 -m pip install --upgrade setuptools
+
 PennyLane-AQT only requires PennyLane for use, no additional external frameworks are needed.
 The plugin can be installed via ``pip``:
 ::

--- a/README.rst
+++ b/README.rst
@@ -55,7 +55,9 @@ Features
 Installation
 ============
 
-.. note::
+PennyLane-AQT requires Python >= 3.10.
+
+.. warning::
     
     If you are using Python 3.12, ensure `setuptools` is up to date prior to installation:
     ::

--- a/setup.py
+++ b/setup.py
@@ -71,9 +71,9 @@ classifiers = [
     "Programming Language :: Python",
     # Make sure to specify here the versions of Python supported
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3 :: Only",
     "Topic :: Scientific/Engineering :: Physics",
 ]


### PR DESCRIPTION
As the name says! 😄 

1. Removed any reference to 3.9 and added 3.10 as the base version. 
2. Tests are done on 3.10->3.12. 
3. Added to the documentation that installation of `setuptools` is required for 3.12 support.