### PR TITLE
Delete references to the removed `QubitStateVector` class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@
 
 ### Breaking changes 💔
 
-* The ``qml.QubitStateVector`` template has been removed. Instead, use :class:`~pennylane.StatePrep`. 
+* The ``qml.QubitStateVector`` template has been removed. Instead, use :class:`~pennylane.StatePrep`.
+  [(#77)](https://github.com/PennyLaneAI/pennylane-aqt/pull/77)
 
 ### Deprecations 👋
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Breaking changes 💔
 
+* The ``qml.QubitStateVector`` template has been removed. Instead, use :class:`~pennylane.StatePrep`. 
+
 ### Deprecations 👋
 
 ### Documentation 📝
@@ -15,6 +17,8 @@
 ### Contributors ✍️
 
 This release contains contributions from (in alphabetical order):
+
+Andrija Paurevic
 
 ---
 # Release 0.39.0

--- a/pennylane_aqt/device.py
+++ b/pennylane_aqt/device.py
@@ -166,7 +166,7 @@ class AQTDevice(QubitDevice):
         rotations = kwargs.pop("rotations", [])
 
         for i, operation in enumerate(operations):
-            if i > 0 and operation.name in {"BasisState", "QubitStateVector", "StatePrep"}:
+            if i > 0 and operation.name in {"BasisState", "StatePrep"}:
                 raise DeviceError(
                     "The operation {} is only supported at the beginning of a circuit.".format(
                         operation.name


### PR DESCRIPTION
**Context:**

Completing the deprecation cycle of `QubitStateVector` (see https://github.com/PennyLaneAI/pennylane/pull/6525)

**Description of the Change:**

Removed all references to the deprecated source code.

[sc-77482]