### PR TITLE
Overload the `batch_transform` to carry over the validation of no analytics

### DIFF
--- a/pennylane_aqt/device.py
+++ b/pennylane_aqt/device.py
@@ -109,7 +109,7 @@ class AQTDevice(QubitDevice):
             raise ValueError(
                 "The aqt.base_device device does not support analytic expectation values"
             )
-        return super().expand_fn(circuit, max_expansion)
+        return super().batch_transform(circuit)
 
     def reset(self):
         """Reset the device and reload configurations."""

--- a/pennylane_aqt/device.py
+++ b/pennylane_aqt/device.py
@@ -104,7 +104,7 @@ class AQTDevice(QubitDevice):
         self.reset()
 
     def batch_transform(self, circuit):
-        """Expand the circuit"""
+        """Transform the batch of circuits"""
         if not circuit.shots:
             raise ValueError(
                 "The aqt.base_device device does not support analytic expectation values"

--- a/pennylane_aqt/device.py
+++ b/pennylane_aqt/device.py
@@ -104,6 +104,7 @@ class AQTDevice(QubitDevice):
         self.reset()
 
     def expand_fn(self, circuit, max_expansion=10):
+        """Expand the circuit"""
         if not circuit.shots:
             raise ValueError(
                 "The aqt.base_device device does not support analytic expectation values"

--- a/pennylane_aqt/device.py
+++ b/pennylane_aqt/device.py
@@ -103,7 +103,7 @@ class AQTDevice(QubitDevice):
 
         self.reset()
 
-    def expand_fn(self, circuit, max_expansion=10):
+    def batch_transform(self, circuit):
         """Expand the circuit"""
         if not circuit.shots:
             raise ValueError(

--- a/pennylane_aqt/device.py
+++ b/pennylane_aqt/device.py
@@ -30,8 +30,6 @@ from pennylane.ops import Adjoint
 from ._version import __version__
 from .api_client import verify_valid_status, submit
 
-BASE_SHOTS = 200
-
 
 class AQTDevice(QubitDevice):
     r"""AQT device for PennyLane.
@@ -94,11 +92,7 @@ class AQTDevice(QubitDevice):
     TARGET_PATH = ""
     HTTP_METHOD = "PUT"
 
-    def __init__(self, wires, shots=BASE_SHOTS, api_key=None, retry_delay=1):
-        if shots is None:
-            raise ValueError(
-                "The aqt.base_device device does not support analytic expectation values"
-            )
+    def __init__(self, wires, shots=None, api_key=None, retry_delay=1):
 
         super().__init__(wires=wires, shots=shots)
         self.shots = shots
@@ -108,6 +102,13 @@ class AQTDevice(QubitDevice):
         self.set_api_configs()
 
         self.reset()
+
+    def expand_fn(self, circuit, max_expansion=10):
+        if not circuit.shots:
+            raise ValueError(
+                "The aqt.base_device device does not support analytic expectation values"
+            )
+        return super().expand_fn(circuit, max_expansion)
 
     def reset(self):
         """Reset the device and reload configurations."""

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -423,10 +423,10 @@ class TestAQTDeviceIntegration:
 
         dev = qml.device("aqt.sim", wires=num_wires, api_key=SOME_API_KEY)
 
-
         assert dev.num_wires == num_wires
-        assert dev.shots.total_shots == shots
-        assert dev.analytic == False
+        # Due to the deprecation of device.shots, the following two properties (shots, analytic) should be changed.
+        assert dev.shots.total_shots is None
+        assert dev.analytic == True
         assert dev.circuit == []
         assert dev.circuit_json == ""
         assert dev.samples is None

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -32,14 +32,10 @@ HTTP_METHOD = "PUT"
 SOME_API_KEY = "ABC123"
 
 test_config = """\
-[main]
-shots = 1000
-
 [default.gaussian]
 hbar = 2
 
 [aqt.sim]
-shots = 99
 api_key = "{}"
 """.format(
     SOME_API_KEY
@@ -467,12 +463,9 @@ class TestAQTDeviceIntegration:
             "pennylane.default_config", qml.Configuration("config.toml")
         )  # force loading of config
 
-        with pytest.warns(
-            qml.exceptions.PennyLaneDeprecationWarning, match="shots on device is deprecated"
-        ):
-            dev = qml.device("aqt.sim", wires=2)
+        dev = qml.device("aqt.sim", wires=2)
 
-        assert dev.shots.total_shots == 99
+        assert dev.shots.total_shots is None  # note that dev.shots is deprecated
         assert API_HEADER_KEY in dev.header.keys()
         assert dev.header[API_HEADER_KEY] == SOME_API_KEY
 
@@ -493,10 +486,7 @@ class TestAQTDeviceIntegration:
         c = qml.Configuration("config.toml")
         monkeypatch.setattr("pennylane.default_config", c)  # force loading of config
 
-        with pytest.warns(
-            qml.exceptions.PennyLaneDeprecationWarning, match="shots on device is deprecated"
-        ):
-            dev = qml.device("aqt.sim", wires=2)
+        dev = qml.device("aqt.sim", wires=2)
 
         assert API_HEADER_KEY in dev.header.keys()
         assert dev.header[API_HEADER_KEY] == SOME_API_KEY
@@ -515,10 +505,7 @@ class TestAQTDeviceIntegration:
             "pennylane.default_config", qml.Configuration("config.toml")
         )  # force loading of config
 
-        with pytest.warns(
-            qml.exceptions.PennyLaneDeprecationWarning, match="shots on device is deprecated"
-        ):
-            dev = qml.device("aqt.sim", wires=2)
+        dev = qml.device("aqt.sim", wires=2)
 
         assert API_HEADER_KEY in dev.header.keys()
         assert dev.header[API_HEADER_KEY] == SOME_API_KEY

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -559,9 +559,17 @@ class TestAQTDeviceIntegration:
         assert dev.samples == MOCK_SAMPLES
 
     def test_analytic_error(self):
-        """Test that instantiating the device with `shots=None` results in an error"""
+        """Test that run the circuit with `shots=None` results in an error"""
+        dev = qml.device("aqt.sim", wires=2, api_key=SOME_API_KEY)
+
+        @qml.qnode(dev)
+        def circuit():
+            qml.RX(0.5, wires=0)
+            qml.RY(1.2, wires=1)
+            return qml.expval(qml.PauliZ(0))
+
         with pytest.raises(ValueError, match="does not support analytic"):
-            dev = qml.device("aqt.sim", wires=2, shots=None)
+            circuit()
 
 
 class TestAQTSimulatorDevices:

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -421,10 +421,8 @@ class TestAQTDeviceIntegration:
     def test_load_from_device_function(self, num_wires, shots):
         """Tests that the AQTDevice can be loaded from PennyLane `device` function."""
 
-        with pytest.warns(
-            qml.exceptions.PennyLaneDeprecationWarning, match="shots on device is deprecated"
-        ):
-            dev = qml.device("aqt.sim", wires=num_wires, shots=shots, api_key=SOME_API_KEY)
+        dev = qml.device("aqt.sim", wires=num_wires, api_key=SOME_API_KEY)
+
 
         assert dev.num_wires == num_wires
         assert dev.shots.total_shots == shots

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -425,7 +425,10 @@ class TestAQTDeviceIntegration:
     def test_load_from_device_function(self, num_wires, shots):
         """Tests that the AQTDevice can be loaded from PennyLane `device` function."""
 
-        dev = qml.device("aqt.sim", wires=num_wires, shots=shots, api_key=SOME_API_KEY)
+        with pytest.warns(
+            qml.exceptions.PennyLaneDeprecationWarning, match="shots on device is deprecated"
+        ):
+            dev = qml.device("aqt.sim", wires=num_wires, shots=shots, api_key=SOME_API_KEY)
 
         assert dev.num_wires == num_wires
         assert dev.shots.total_shots == shots
@@ -464,7 +467,10 @@ class TestAQTDeviceIntegration:
             "pennylane.default_config", qml.Configuration("config.toml")
         )  # force loading of config
 
-        dev = qml.device("aqt.sim", wires=2)
+        with pytest.warns(
+            qml.exceptions.PennyLaneDeprecationWarning, match="shots on device is deprecated"
+        ):
+            dev = qml.device("aqt.sim", wires=2)
 
         assert dev.shots.total_shots == 99
         assert API_HEADER_KEY in dev.header.keys()
@@ -487,7 +493,10 @@ class TestAQTDeviceIntegration:
         c = qml.Configuration("config.toml")
         monkeypatch.setattr("pennylane.default_config", c)  # force loading of config
 
-        dev = qml.device("aqt.sim", wires=2)
+        with pytest.warns(
+            qml.exceptions.PennyLaneDeprecationWarning, match="shots on device is deprecated"
+        ):
+            dev = qml.device("aqt.sim", wires=2)
 
         assert API_HEADER_KEY in dev.header.keys()
         assert dev.header[API_HEADER_KEY] == SOME_API_KEY
@@ -506,7 +515,10 @@ class TestAQTDeviceIntegration:
             "pennylane.default_config", qml.Configuration("config.toml")
         )  # force loading of config
 
-        dev = qml.device("aqt.sim", wires=2)
+        with pytest.warns(
+            qml.exceptions.PennyLaneDeprecationWarning, match="shots on device is deprecated"
+        ):
+            dev = qml.device("aqt.sim", wires=2)
 
         assert API_HEADER_KEY in dev.header.keys()
         assert dev.header[API_HEADER_KEY] == SOME_API_KEY
@@ -528,8 +540,9 @@ class TestAQTDeviceIntegration:
         """Tests that a PennyLane QNode successfully executes with a
         mocked out online API."""
 
-        dev = qml.device("aqt.sim", wires=2, shots=10, api_key=SOME_API_KEY)
+        dev = qml.device("aqt.sim", wires=2, api_key=SOME_API_KEY)
 
+        @qml.set_shots(10)
         @qml.qnode(dev)
         def circuit(x, y):
             qml.RX(x, wires=0)


### PR DESCRIPTION
It used to be super hard to deprecate the device.shots. But we can try:
 - [x] `BASE_SHOTS` has been removed
 - [x] Instead, the shots checking has been migrated to a newly overloaded function `expand_fn`